### PR TITLE
Fix image decoding error on Firefox

### DIFF
--- a/src/scripts/ViewerControlsImage.vue
+++ b/src/scripts/ViewerControlsImage.vue
@@ -60,14 +60,14 @@ export default {
 			if (!this.$image)
 				return;
 
-			if (!this.$image.complete) {
+			this.$store.dispatch('setLoading');
 
-				this.$store.dispatch('setLoading');
-
-				this.$image.decode().then(() => {
+			let recheck = setInterval( () => {
+				if (this.$image.complete) {
 					this.$store.dispatch('setReady');
-				});
-			}
+					clearInterval(recheck);
+				}
+			}, 1000);
 		}
 	},
 	mounted () {


### PR DESCRIPTION
As FF doesn't want to decode our images being currently generated in the backend, I took the liberty to check every 1s if it's ready instead of trying to decode it.

Fixes: https://github.com/owncloud/files_mediaviewer/issues/51 https://github.com/owncloud/files_mediaviewer/issues/55