### PR TITLE
[1.0.0] Preload only video metadata

### DIFF
--- a/src/scripts/Viewer.vue
+++ b/src/scripts/Viewer.vue
@@ -5,7 +5,7 @@
 				<div class="viewer__wrapper">
 					<div class="viewer__slide" v-for="(slide, index) in list" :key="index">
 						<img v-if="getType(slide) === 'image'" class="viewer__media viewer__media--image" :src="thumbPath(index, slide)" :alt="slide.name">
-						<video v-if="getType(slide) === 'video'" class="viewer__media viewer__media--video" :controls="isFullscreen" :class="{ 'viewer__media--video-paused' : isPaused }">
+						<video v-if="getType(slide) === 'video'" class="viewer__media viewer__media--video" :controls="isFullscreen" :class="{ 'viewer__media--video-paused' : isPaused }" preload="metadata">
 							<source :src="webdavPath(index, slide)" :type="slide.mimetype">
 						</video>
 					</div>


### PR DESCRIPTION
Some browsers like Firefox would download the whole video, which makes
preloading of hidden videos very slow.

I've tested this in Firefox and it seems to solve some performance issues due to preloading too much data.

Fixes https://github.com/owncloud/files_mediaviewer/issues/40