### PR TITLE
Reset store on deactivation

### DIFF
--- a/src/scripts/Viewer.vue
+++ b/src/scripts/Viewer.vue
@@ -206,6 +206,7 @@ export default {
 
 	deactivated () {
 		this.swiper.destroy();
+		this.$store.dispatch('resetAll');
 		this.list = null;
 	},
 

--- a/src/scripts/store.js
+++ b/src/scripts/store.js
@@ -53,6 +53,18 @@ export default {
 		},
 		setTransitionState(state, setTo) {
 			state.isInTransition = setTo;
+		},
+		resetAll(state) {
+			state.activeIndex= 0;
+			state.maxIndex = 0;
+			state.activeMediaItem = {};
+			state.isLoading = false;
+			state.isInTransition = false;
+			state.video = {
+				isPaused : true,
+				isMuted : false,
+				isFullscreen : false
+			};
 		}
 	},
 	actions : {
@@ -78,6 +90,9 @@ export default {
 		},
 		setVideoState(context, payload) {
 			context.commit('setVideoState', payload);
+		},
+		resetAll(context) {
+			context.commit('resetAll');
 		}
 	}
 };


### PR DESCRIPTION
Reset the store contents when deactivating the swiper.

Fixes: https://github.com/owncloud/files_mediaviewer/issues/74
Fixes: https://github.com/owncloud/files_mediaviewer/issues/75
Fixes: https://github.com/owncloud/files_mediaviewer/issues/76
Fixes: https://github.com/owncloud/files_mediaviewer/issues/77

@skshetry please retry. Worked for me … but then again, the error didn't occur too often as well.