### PR TITLE
OCA.Mediaviewer

### DIFF
--- a/src/scripts/Viewer.vue
+++ b/src/scripts/Viewer.vue
@@ -113,10 +113,10 @@ export default {
 		},
 
 		fetchFileList(callback) {
-			
+
 			let fetch = new Promise( (resolve, reject) => {
 
-				let list = _.filter(FileList.files, (file) => {
+				let list = _.filter(OCA.Mediaviewer.files, (file) => {
 					return _.contains(this.$app.config.mimetypes, file.mimetype);
 				});
 

--- a/src/scripts/init.js
+++ b/src/scripts/init.js
@@ -1,7 +1,14 @@
-import app from './setup.js';
+if (!OCA.Mediaviewer) {
+	/**
+	 * @namespace
+	 */
+	OCA.Mediaviewer = {};
+}
+
+OCA.Mediaviewer.app = require('./setup.js').default;
 
 $(document).ready(function () {
-
+	const app = OCA.Mediaviewer.app;
 	const mountPoint = $('<div>', {
 		id: app.name,
 		html: '<div>'
@@ -10,18 +17,20 @@ $(document).ready(function () {
 	if (!OCA.Files) {
 		return;
 	}
-
+	
 	// ---- Register fileactions -------
 
-	let actionHandler = (fileName) => {
+	let actionHandler = (fileName, context) => {
 		$('body').append(mountPoint);
-		
+
+		OCA.Mediaviewer.files = context.fileList.files;
+
 		OC.addScript(app.name, app.name).then(() => {
 			OC.redirect(OC.joinPaths('#', app.name, fileName));
 		});
 	};
 
-	app['config'].mimetypes.forEach( (mimetype) => {
+	app.config.mimetypes.forEach( (mimetype) => {
 
 		let ViewMedia = {
 			mime: mimetype,


### PR DESCRIPTION
* Fetch file list from `actionHandler … context`
* store file list in OCA namespace

Fixes the error, where `FileList.files` is outside of the main files-view (eg. favorites)

Fixes: https://github.com/owncloud/files_mediaviewer/issues/73