### PR TITLE
Document how to support more media types

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,25 @@ Requires
 * NPM
 
 Run `npm install && npm run build` to build.
+
+## Supporting more media types
+
+First, make sure you have installed ImageMagick and its imagick PECL extension.
+Next add a few new entries to your **config/config.php** configuration file.
+
+```
+  'preview_max_scale_factor' => 1,
+  'enabledPreviewProviders' =>
+  array (
+    0 => 'OC\\Preview\\PNG',
+    1 => 'OC\\Preview\\JPEG',
+    2 => 'OC\\Preview\\GIF',
+    11 => 'OC\\Preview\\Illustrator',
+    12 => 'OC\\Preview\\Postscript',
+    13 => 'OC\\Preview\\Photoshop',
+    14 => 'OC\\Preview\\TIFF'
+  ),
+```
+
+Look at the sample configuration (config.sample.php) in your config folder if you need more information about how the config file works.
+That's it. You should be able to see more media types in your slideshows and galleries as soon as you've installed the app.


### PR DESCRIPTION
I copied this from owncloud/gallery/README.md - according to @DeepDiver1975 it works the same way in this app.

As I want to link to this in the release blogpost, it would be cool to have it in master or so. It might also be a good idea to link to this in the marketplace description; When we say "Support for a large selection of image and video formats (depending on server setup)" we should also add how you can enable it.