### PR TITLE
add time display to viewer controls

### DIFF
--- a/src/scripts/ViewerControlsVideo.vue
+++ b/src/scripts/ViewerControlsVideo.vue
@@ -12,6 +12,7 @@
 				<!-- Swipe controls -->
 			</nav-controls>
 			<div class="viewer__controls__subgroup">
+				<span class="viewer__control__count" v-text="showTimeInfo()"></span>
 				<button class="viewer__control icon__replay" :disabled="currentTime === 0" @click="skipTo(0)" v-translate>Replay</button>
 				<button class="viewer__control icon__play" :class="[isPaused ? 'icon__play' : 'icon__pause']" @click="togglePlay()" v-translate>Play</button>
 				<button class="viewer__control" :class="[isMuted ? 'icon__volume_down' : 'icon__volume_up']" @click="toggleSound()" v-translate>Mute</button>
@@ -153,6 +154,12 @@ export default {
 		handleTimeupdate () {
 			this.currentTime = Math.round(this.$video.currentTime);
 		},
+
+		showTimeInfo() {
+			let current = this.getDisplayTime(this.currentTime);
+			let duration = this.totalDisplayTime;
+			return `${current} / ${duration}`;
+		}
 	},
 	mounted () {
 		this.$bus.$on('swiper:slideChangeTransitionEnd', () => {
@@ -207,6 +214,12 @@ export default {
 		},
 		$scrubber () {
 			return $('.viewer__control__scrubber').get(0);
+		},
+
+		totalDisplayTime () {
+			// this.duration is not rounded as opposed to this.currentTime
+			let duration = Math.round(this.duration);
+			return this.getDisplayTime(duration);
 		}
 	}
 };

--- a/src/scripts/helper.js
+++ b/src/scripts/helper.js
@@ -18,6 +18,23 @@ const helper = {
 
 		closeViewer () {
 			this.$router.push('/');
+		},
+
+		getDisplayTime (time) {
+			if (time === 0) return "00:00";
+
+			// when switching between previews, currentTime is not rounded somehow
+			time = Math.round(time);
+
+			let hour = Math.floor(time / 3600);
+			let minute = Math.floor(time % 3600 / 60);
+			let second = time % 60;
+
+			let times = [minute, second];
+			if ( hour > 0 ) times = [hour, minute, second];
+			times = times.map( el => el < 10 ? (el+"").padStart(2, "0") : el);
+
+			return times.join(":");
 		}
 	},
 	computed : {


### PR DESCRIPTION
hi,
another try, since i committed merged code in the topic branch in the previous pull request (#223)
a few remarks:  

- i wasn't sure about your styling and i didn't wanna mess with your styles, so i used the `viewer__control__count css` class to style the display for test purposes (which disappears on small screens)
- `totalDisplayTime` is computed because it doesn't change during the video
- i put `getDisplayTime()` in helper.js since it seemed more like a utility function to me
- the function `showTimeInfo()` aggregates the displayed string
