### PR TITLE
Add bgcolor and adopt the height of the video scrubber

### DIFF
--- a/src/styles/_viewerControls.scss
+++ b/src/styles/_viewerControls.scss
@@ -19,7 +19,7 @@
 		display: block;
 		position: absolute;
 		color: white;
-		transform: translate(-50%, -150%);
+		transform: translate(-50%, -190%);
 		top: 0;
 		left: 50%;
 		white-space: nowrap;
@@ -45,11 +45,12 @@
 		position: absolute;
 		left: 0;
 		right: 0;
-		top: 0;
-		height: 5px;
+		top: -1px;
+		height: 10px;
 		width: 100%;
 		transform: translateY(-100%);
 		transition: height .25s;
+		background: rgba(0, 0, 0, 0.5);
 
 		// Juicebar
 		> div {
@@ -119,7 +120,7 @@
 
 	// --- Enlarge juicebar on hovering over controlbar
 	&:hover > .viewer__control__scrubber {
-		height: 10px;
+		height: 15px;
 	}
 
 	@media (max-width: 650px) {


### PR DESCRIPTION
With this PR I added a background color to the scrubber. Especially with long videos it was not obvious at the beginning that there is a scrubber.

The height of the scrubber was increased by 5 pixels. @PVince81  can you do a re-test with these changes?

Fixes: https://github.com/owncloud/files_mediaviewer/issues/26

### Screenshot
Before:
![image](https://user-images.githubusercontent.com/33026403/90242826-ff84a880-de2d-11ea-9f2d-0db68f21c1af.png)


After: 
![image](https://user-images.githubusercontent.com/33026403/90242406-445c0f80-de2d-11ea-9b02-d1073307a525.png)

###
Manually tested in Chrome browser
