### PR TITLE
Possibly fix Gallery & files_mediaviewer compatibility issue.

### DIFF
--- a/src/scripts/init.js
+++ b/src/scripts/init.js
@@ -49,7 +49,9 @@ $(document).ready(function () {
 			actionHandler
 		};
 
-		OCA.Files.fileActions.registerAction(ViewMedia);
-		OCA.Files.fileActions.setDefault(mimetype, app.name);
+		if (OCA.Files.fileActions) {
+			OCA.Files.fileActions.registerAction(ViewMedia);
+			OCA.Files.fileActions.setDefault(mimetype, app.name);
+		}
 	});
 });


### PR DESCRIPTION
This simple, no-harm change checks that `OCA.Files.fileActions` exists
before using it.  This seems to fix #102, the compatibility issue between the
files_mediaviewer app and the old Gallery app.  The edit allows
javascript to continue without throwing an exception if
`OCA.Files.fileActions` does not exist.  For some reason this happens
when both Gallery and files_mediaviewer are enabled in my installation
of OwnCloud.