### PR TITLE
Update default.scss

### DIFF
--- a/src/styles/default.scss
+++ b/src/styles/default.scss
@@ -23,7 +23,7 @@ $core-image-path : '../../../core/img';
 $app-image-path : '../img';
 
 #{$namespace} {
-	@import "../../node_modules/swiper/dist/css/swiper.min";
+	@import "../../node_modules/swiper/dist/css/swiper.min.css";
 
 	@import "base";
 	@import "transitions";


### PR DESCRIPTION
Because of an error of CI found in: https://github.com/owncloud/files_mediaviewer/pull/481 (Bump swiper from 4.5.1 to 7.0.1)

```
ERROR in ./src/styles/default.scss (./node_modules/css-loader/dist/cjs.js!./node_modules/sass-loader/dist/cjs.js!./src/styles/default.scss)
    Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
    SassError: Can't find stylesheet to import.
       │
    26 │     @import "../../node_modules/swiper/dist/css/swiper.min";
       │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

The filename should be corrected:

`node_modules/swiper/dist/css/swiper.min` --> `node_modules/swiper/dist/css/swiper.min.css`

Double checked locally regarding the filename.