### PR TITLE
Fix some dependency warnings when building/installing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@types/moment-duration-format": "^2.2.3",
     "easygettext": "^2.17.0",
     "moment-duration-format": "^2.3.2",
+    "svelte": "^3.x",
     "swiper": "^6.5.1",
     "vue": "^2.6.14",
     "vue-router": "^3.5.2",
@@ -25,7 +26,7 @@
     "webpack-cli": "^4.8.0"
   },
   "scripts": {
-    "build": "webpack --progress",
+    "build": "webpack --progress --mode=production",
     "watch": "webpack --watch --mode=development"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2863,6 +2863,11 @@ supports-color@^8.0.0:
   dependencies:
     has-flag "^4.0.0"
 
+svelte@^3.x:
+  version "3.42.4"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.42.4.tgz#838ed98fa7b26fc5fffe4df0d7ba345f1c54cf4f"
+  integrity sha512-DqC0AmDdBrrbIA+Kzl3yhBb6qCn4vZOAfxye2pTnIpinLegyagC5sLI8Pe9GPlXu9VpHBXIwpDDedpMfu++epA==
+
 swiper@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/swiper/-/swiper-6.5.1.tgz#795630e45bbebb3b3b2945d55c22ffdcf5536c1b"


### PR DESCRIPTION
As the title says...

The remaining warning when running `yarn install`:
`warning "easygettext > @vue/compiler-sfc@3.0.3" has incorrect peer dependency "vue@3.0.3"`
cant be solved atm as it would conflict with other dependencies (vue-template-compiler) resulting in build errors. (at least I do not have the knowledge to fix this...)

Fixing this, the build does no longer return any warnings with regards to dependencies or the use of webpack