### PR TITLE
Fix video playback in Safari

### DIFF
--- a/src/scripts/ViewerControlsVideo.vue
+++ b/src/scripts/ViewerControlsVideo.vue
@@ -48,7 +48,8 @@ export default {
 			mousePos    : {
 				type    : Number,
 				default : 0
-			}
+			},
+			initialized: false
 		};
 	},
 	methods : {
@@ -118,6 +119,8 @@ export default {
 
 				this.mousePos = Math.round(pct / 100 * this.duration);
 			});
+
+			this.initialized = true;
 		},
 
 		handleError () {
@@ -163,7 +166,9 @@ export default {
 	},
 	mounted () {
 		this.$bus.$on('swiper:slideChangeTransitionEnd', () => {
-			this.init();
+			if (this.initialized) {
+				this.init();
+			}
 		});
 		this.$bus.$on('swiper:init', () => {
 			this.init();


### PR DESCRIPTION
Opening a video from the file list which is not the first one will trigger the `init()` method twice: First time because of `swiper:slideChangeTransitionEnd`, second time because of `swiper:init`. This causes issues in Safari, therefore we need to make sure `swiper:init` does the first call to `init()`.

### Steps to reproduce

Using Safari browser:

1. Upload 2 videos
2. Refresh page
3. Open the second video -> video should play after clicking play