### PR TITLE
chore: update dependabot to weekly Sunday schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,63 +1,29 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "22:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: swiper
-    versions:
-    - 6.4.10
-    - 6.4.11
-    - 6.4.12
-    - 6.4.14
-    - 6.4.15
-    - 6.4.9
-    - 6.5.0
-    - 6.5.5
-    - 6.5.6
-    - 6.5.7
-  - dependency-name: css-loader
-    versions:
-    - 5.0.1
-    - 5.0.2
-    - 5.1.0
-    - 5.1.1
-    - 5.1.2
-    - 5.1.3
-    - 5.2.0
-    - 5.2.1
-  - dependency-name: "@babel/core"
-    versions:
-    - 7.12.13
-    - 7.12.16
-    - 7.12.17
-    - 7.13.1
-    - 7.13.10
-    - 7.13.13
-    - 7.13.14
-    - 7.13.15
-    - 7.13.8
-  - dependency-name: y18n
-    versions:
-    - 4.0.1
-  - dependency-name: "@babel/preset-env"
-    versions:
-    - 7.13.10
-    - 7.13.12
-    - 7.13.9
-  - dependency-name: webpack-cli
-    versions:
-    - 4.4.0
-    - 4.5.0
-  - dependency-name: pug-code-gen
-    versions:
-    - 3.0.2
-  - dependency-name: sass-loader
-    versions:
-    - 10.1.1
-  - dependency-name: webpack
-    versions:
-    - 4.46.0
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: '22:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: '22:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
This PR adds/updates the Dependabot configuration for this repository.

Dependabot is configured to run weekly (Sunday at 22:00 UTC) with a limit of 5 open pull requests per ecosystem. Minor and patch updates are grouped into a single PR per ecosystem to reduce the number of concurrent update PRs, lowering maintainer overhead and CI load. Major version updates remain as individual PRs so they receive deliberate review.
