### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+
+## [1.1.1] - 2026-07-22
+
+### Changed
+- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
+
+## [1.1.0] - 2026-06-29
+
+### Changed
+- ownCloud 11 compatible release (oc 11.0.0-rc1).
+
 ## [1.0.5] - 2021-11-09
 
 ### Changed
@@ -73,7 +84,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Initial release
 
-[Unreleased]: https://github.com/owncloud/files_mediaviewer/compare/v1.0.5...HEAD
+[Unreleased]: https://github.com/owncloud/files_mediaviewer/compare/v1.1.1..master
+[1.1.1]: https://github.com/owncloud/files_mediaviewer/compare/v1.1.0..v1.1.1
+[1.1.0]: https://github.com/owncloud/files_mediaviewer/compare/v1.0.5..v1.1.0
 [1.0.5]: https://github.com/owncloud/files_mediaviewer/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/owncloud/files_mediaviewer/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/owncloud/files_mediaviewer/compare/v1.0.2...v1.0.3

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@ A media viewer that adds image and video viewing capabilities to Files view and 
 - Mobile support</description>
 	<licence>GPLv2</licence>
 	<author>Felix Heidecke</author>
-	<version>1.1.0</version>
+	<version>1.1.1</version>
 	<namespace>Mediaviewer</namespace>
 	<documentation>
 		<developer>https://github.com/owncloud/files_mediaviewer/blob/master/README.md</developer>


### PR DESCRIPTION
Patch-level version bump (1.1.0 -> 1.1.1) for the oc11 (11.0.0) complete release. Part of the G2 code-signing re-release.