### PR TITLE
ci: scan the distribution tree for known vulnerabilities

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,32 @@
+name: Security Scan
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  schedule:
+    # Weekly, so CVEs published against already-released code surface without a
+    # code change. That is how the outdated bundled rclone would have been found.
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  trivy:
+    name: Trivy
+    uses: owncloud/reusable-workflows/.github/workflows/trivy.yml@main
+    with:
+      # `make dist` runs js-deps/build-js, and the Makefile aborts at parse time
+      # when yarn is missing ($(error yarn is not available on your system)).
+      node-version: '18'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -26,7 +26,3 @@ jobs:
   trivy:
     name: Trivy
     uses: owncloud/reusable-workflows/.github/workflows/trivy.yml@main
-    with:
-      # `make dist` runs js-deps/build-js, and the Makefile aborts at parse time
-      # when yarn is missing ($(error yarn is not available on your system)).
-      node-version: '18'


### PR DESCRIPTION
## Why

The oc11 bundle had a blind spot: `migrate_to_ocis` shipped an rclone binary built with Go 1.22.4 carrying **48 HIGH/CRITICAL** CVEs (measured in CI, incl. CVE-2025-68121 in crypto/tls), and nothing reported it. Two reasons, both now fixed — but neither was app-specific, so every app repo gets the same scan.

1. Nothing scanned the app repos at all. Findings mostly appear when a CVE is published against code released months ago, with no repository activity to trigger CI — hence the weekly schedule here.
2. The scan that did exist (on the docker image) could not see the binary: Trivy's gobinary analyzer only inspects files with an exec bit, and the complete tarball normalized every file to `0644` (owncloud/server-release#52).

## What

`.github/workflows/security-scan.yml`, calling `owncloud/reusable-workflows/.github/workflows/trivy.yml@main`. Runs on push to master, on pull requests, weekly on Monday 03:00 UTC, and on demand.

The reusable workflow builds the app (`make dist`) and runs `trivy rootfs` over the resulting distribution tree, failing on HIGH/CRITICAL findings that have a fix available (`ignore-unfixed: true`, matching the docker image scans).

Two details worth knowing when you read it:

- **`rootfs`, not `fs`.** The `fs` scanner does not enable the gobinary analyzer, so bundled Go binaries are silently skipped. Verified on trivy 0.55.0 and 0.69.3.
- **The unpacked tree, not the `.tar.gz`.** Trivy does not recurse into archives, and composer/npm dependencies only exist after the build.

The scan path is autodetected (`build/dist/<app>`, `build/artifacts/appstore/<app>`, `build/appstore/<app>`), so this file is identical in every app repo. A missing tree fails the job rather than scanning nothing — Trivy reports a nonexistent path as clean.

## Findings

If the scan is red here for something unrelated to this PR, that is a real finding in the released app and worth its own issue rather than a reason to weaken the gate.

Accepting a finding goes in `.trivyignore.yaml`, and each entry carries:

- `expired_at` — the acceptance stops suppressing once the date passes, so it gets revisited instead of buried. Verified against Trivy: an expired entry is reported again.
- `paths` — scoped to the affected file, so the acceptance cannot silently spread to another component.
- `statement` — why it is accepted.

The caller has to name that file (`trivyignores: .trivyignore.yaml`), because Trivy only auto-discovers the plain `.trivyignore` format, and the plain format cannot express expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)